### PR TITLE
🐛 Fix directory path of dependabot Docker

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,6 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/" # Location of package manifests
+    directory: "/.devcontainer"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
# ⭐ What does this PR do?

- 🐛 Fix directory path of dependabot Docker

